### PR TITLE
Fix: Allow installation on PHP 8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.1.0...main`][1.1.0...main].
 
+### Fixed
+
+- Allowed installation on PHP 8.6 ([#4]), by [@localheinz]
+
 ## [`1.1.0`][1.1.0]
 
 For a full diff see [`1.0.1...1.1.0`][1.0.1...1.1.0].
@@ -33,5 +37,6 @@ For a full diff see [`2655ea1...1.0.1`][2655ea1...1.0.1].
 
 [#1]: https://github.com/ergebnis/agent-detector/pull/1
 [#2]: https://github.com/ergebnis/agent-detector/pull/2
+[#4]: https://github.com/ergebnis/agent-detector/pull/4
 
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "security": "https://github.com/ergebnis/agent-detector/blob/main/.github/SECURITY.md"
   },
   "require": {
-    "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+    "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0 || ~8.6.0"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.50.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ea61c9ec618495ae696b3b143ee4b99",
+    "content-hash": "cd696770156c0a28f2ddfe7fc95fc1e3",
     "packages": [],
     "packages-dev": [
         {
@@ -6710,7 +6710,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0 || ~8.6.0"
     },
     "platform-dev": {},
     "platform-overrides": {


### PR DESCRIPTION
This pull request

- [x] allows installation on PHP 8.6

Related to https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9542.